### PR TITLE
删除特征性的UA

### DIFF
--- a/api.py
+++ b/api.py
@@ -69,7 +69,7 @@ class BilibiliHyg:
             }
         else:
             self.headers = {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BHYG/0.7.7",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)",
             }
 
         self.headers["Cookie"] = self.config["cookie"]

--- a/login.py
+++ b/login.py
@@ -445,7 +445,7 @@ def interactive_login(sentry_sdk = None):
     global sdk
     sdk = sentry_sdk
     headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BHYG/0.7.7"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
     }
 
     session = requests.session()


### PR DESCRIPTION
留着容易被叔叔爆破，会在服务器里留下日志，万一找上门了就麻烦了